### PR TITLE
Initialize autoload module "quickrun"

### DIFF
--- a/autoload/unite/sources/quickrun_config.vim
+++ b/autoload/unite/sources/quickrun_config.vim
@@ -6,7 +6,7 @@ let g:unite_quickrun_config_selected_prefix =
 
 
 function! unite#sources#quickrun_config#quickrun_config_all()
-	return copy(extend(copy(g:quickrun#default_config), get(g:, "quickrun_config", {})))
+	return copy(extend(copy(get(g:, "quickrun#default_config", {})), get(g:, "quickrun_config", {})))
 endfunction
 
 function! s:quickrun_config_type_filetype(filetype)


### PR DESCRIPTION
quickrun を全く使っていない状態で Unite quickrun_config をすると、
g:quickrun#default_confing が未定義だと怒られるので…。

もっと良い方法があるでしょうか。
